### PR TITLE
update user guide & API doc links

### DIFF
--- a/download.html
+++ b/download.html
@@ -20,7 +20,7 @@
 
     <p><span style="font-weight: bolder">Source download:</span> <a href="https://downloads.haskell.org/~cabal/Cabal-3.2.0.0/Cabal-3.2.0.0.tar.gz">Cabal-3.2.0.0.tar.gz</a></p>
 
-    <p>Please see the <a href="https://downloads.haskell.org/~cabal/Cabal-latest/doc/users-guide/">User's guide</a>, the <a href="https://downloads.haskell.org/~cabal/Cabal-latest/doc/API/Cabal/">API documentation</a>, and the <a href="http://hackage.haskell.org/package/Cabal/changelog">change log</a>.</p>
+    <p>Please see the <a href="https://cabal.readthedocs.io">User's guide</a>, the <a href="http://hackage.haskell.org/package/Cabal">API documentation</a>, and the <a href="http://hackage.haskell.org/package/Cabal/changelog">change log</a>.</p>
 
     <h2>cabal-install tool (version 3.2.0.0)</h2>
 


### PR DESCRIPTION
This updates the user guide link to the latest stable doc at readthedocs, and the API doc link to the latest released API docs at hackage, to help avoid the problem of stale cabal docs discussed at #8.