### PR TITLE
Remove outdated questions

### DIFF
--- a/FAQ.html
+++ b/FAQ.html
@@ -1,463 +1,62 @@
-
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml"
-><head
-  ><title
-    >Cabal FAQ</title
-    ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
-     /><meta name="generator" content="pandoc"
-     /><link rel="stylesheet" href="nominolo.css" type="text/css" media="all" />
-</head
-  ><body>
-    <h1 class="mainheader"><a href="index.html">The Haskell Cabal</a> <span class="subheading">| FAQ</span></h1>
-    <div id="contents"
-    ><h2
-      >Contents</h2
-      ><p
-      >Select the name of a problem to jump to a full explanation and solution.</p
-      ><dl
-      ><dt
-	><a href="#dependencies-conflict"
-	  >Dependencies conflict</a
-	  ></dt
-	><dd
-	><pre
-	  ><code
-	    > cabal: dependencies conflict: ghc-6.10.1 requires process ==1.0.1.1 however
- process-1.0.1.1 was excluded because ghc-6.10.1 requires process ==1.0.1.0
-</code
-	    ></pre
-	  ></dd
-	><dt
-	><a href="#hidden-packages-a"
-	  >Hidden packages (a)</a
-	  ></dt
-	><dd
-	><p
-	  >What is this hidden package? You're writing your own package and you get:</p
-	  ><pre
-	  ><code
-	    > Could not find module `Data.Map': it is a member of package
- containers-0.1.0.0, which is hidden.
-</code
-	    ></pre
-	  ></dd
-	><dt
-	><a href="#hidden-packages-b"
-	  >Hidden packages (b)</a
-	  ></dt
-	><dd
-	><p
-	  >You're building some other package and you get:</p
-	  ><pre
-	  ><code
-	    > Could not find module `Data.Map': it is a member of package
- containers-0.1.0.0, which is hidden.
-</code
-	    ></pre
-	  ></dd
-	><dt
-	><a href="#runprocess-does-not-exist"
-	  >runProcess: does not exist</a
-	  ></dt
-	><dd
-	><p
-	  >You're building a package on Windows and you get:</p
-	  ><pre
-	  ><code
-	    > sh: runProcess: does not exist (No such file or directory)
-</code
-	    ></pre
-	  ></dd
-	><dt
-	><a href="#exitfailure-1"
-	  >ExitFailure 1</a
-	  ></dt
-	><dd
-	><p
-	  ><code
-	    >ExitFailure 1</code
-	    > ??! Where is the real error message?</p
-	  ><pre
-	  ><code
-	    >cabal: Error: some packages failed to install: foo-1.0 failed during the
-configure step. The exception was: exit: ExitFailure 1
-</code
-	    ></pre
-	  ></dd
-	><dt
-	><a href="#parsec-2-vs-3"
-	  >Parsec 2 vs 3</a
-	  ></dt
-	><dd
-	><p
-	  >I just used cabal to install parsec. Why did it give me version 2 rather than 3?</p
-	  ></dd
-	><dt
-	><a href="#runghc-setup-complains-of-missing-packages"
-	  ><code
-	    >runghc Setup</code
-	    > complains of missing packages</a
-	  ></dt
-	><dd
-	><pre
-	  ><code
-	    >$ runghc Setup.hs configure
-Configuring blah-1.0...
-Setup.hs: At least the following dependencies are missing:
-time -any
-</code
-	    ></pre
-	  ><p
-	  >But I just did <code
-	    >cabal install time</code
-	    >! What is going on?</p
-	  ></dd
-	><dt
-	><a href="#cabal-goes-into-an-infinite-loop--runs-out-of-memory"
-	  >Cabal goes into an infinite loop / runs out of memory</a
-	  ></dt
-	><dd
-	><p
-	  >I just upgraded to ghc-6.10 and now cabal runs out of memory when I try to install something</p
-	  ><pre
-	  ><code
-	    >Resolving dependencies...
-cabal: memory allocation failed (requested 2097152 bytes)
-</code
-	    ></pre
-	  ></dd
-	><dt
-	><a href="#internal-error-invalid-install-plan"
-	  >internal error: could not construct a valid install plan</a
-	  ></dt
-	><dd
-	><pre
-	  ><code
-	    >$ cabal install leksah
-Resolving dependencies...
-cabal: internal error: could not construct a valid install plan.
-The proposed (invalid) plan contained the following problems:
-The following packages are involved in a dependency cycle leksah-0.10.0.4
-</code
-	    ></pre
-	  ><p
-	  >What's going on? How do I fix it?</p
-	  ></dd
-	></dl
-      ></div
-    ><div id="dependencies-conflict"
-    ><h2
-      >Dependencies conflict</h2
-      ><blockquote
-      ><pre
-	><code
-	  >Resolving dependencies...
-cabal: dependencies conflict: ghc-6.10.1 requires process ==1.0.1.1 however
-process-1.0.1.1 was excluded because ghc-6.10.1 requires process ==1.0.1.0
-</code
-	  ></pre
-	><p
-	>What does this message mean? It makes little sense to me &#8212; ghc-6.10.1 requires both <code
-	  >process ==1.0.1.1</code
-	  > and <code
-	  >process ==1.0.1.0</code
-	  >?</p
-	></blockquote
-      ><p
-      >Yes, that's exactly what it looks like to Cabal which is why it is horribly confused.</p
-      ><p
-      >The reason is shadowing between the global and user package dbs. The way ghc package databases work is that the user one is just slapped on top of the global one. Like <code
-	>Data.Map.union</code
-	>.</p
-      ><p
-      >Suppose you've got these packages registered in the global package db:</p
-      ><pre
-      ><code
-	>   A-1
-  / |
- /  |
-B-1 |
- \  |
-  \ |
-   C-1.0.1.0
-</code
-	></pre
-      ><p
-      >Now, suppose you register B-1 in the user package db, then it masks the existing B-1 from the global db. But suppose that you build this instance against C-1.0.1.1...</p
-      ><pre
-      ><code
-	>   A-1
-  / \
- /   \
-B-1   \
- \     C-1.0.1.0
-  \
-   C-1.0.1.1
-</code
-	></pre
-      ><p
-      >Oh no! Now A-1 appears to depend on two versions of C! The cabal-install dependency resolver is designed to look for solutions where this does not happen, but here it's already happened in the installed packages, so it cannot ever pick the A-1 package as part of an install plan.</p
-      ><p
-      >It's not just cabal-install that will get confused here. ghc --make will too. If you're lucky you'll get linker errors. If you're unlucky you'll get segfaults.</p
-      ><p
-      >The solution we've been discussing for the next major ghc release is to track package ABIs and possibly even to allow slotting packages in their ABI. That would make this problem disappear and generally allow safer and more flexible management of installed packages.</p
-      ><p
-      >In the mean time I'm thinking of making the representation of installed package databases record broken packages. Then when we overlay package databases we could mark clashes like the above as breaking A-1. We should also try and get the solver to help us find solutions that avoid getting into this situation in the first place.</p
-      ><blockquote
-      ><p
-	>And, more importantly, how do I solve this?</p
-	></blockquote
-      ><p
-      >Run <code
-	>ghc-pkg list</code
-	> and look for packages where you have the same version registered in the user and global package db. Unreigister the user one. For example you might have <code
-	>Cabal-1.6.0.1</code
-	> registered per-user and globally.</p
-      ><p
-      >In this specific example you should also unregister <code
-	>process-1.0.1.1</code
-	>:</p
-      ><pre
-      ><code
-	>ghc-pkg unregister --user process-1.0.1.1
-</code
-	></pre
-      ><p
-      >If it says it'll break other things, then do it anyway using <code
-	>--force</code
-	>. But you will need to rebuild all those other packages that get broken. To check what packages are broken use:</p
-      ><pre
-      ><code
-	>ghc-pkg check
-</code
-	></pre
-      ><p
-      >To avoid this problem in the future, avoid upgrading core packages. The latest version of cabal-install has disabled the <code
-	>upgrade</code
-	> command to make it a bit harder for people to break their systems in this way.</p
-      ></div
-    ><div id="hidden-packages-a"
-    ><h2
-      >Hidden packages (a)</h2
-      ><p
-      >You build a package that you are writing yourself and get a message like:</p
-      ><pre
-      ><code
-	>Could not find module `Data.Map': it is a member of package
-containers-0.1.0.0, which is hidden.
-</code
-	></pre
-      ><p
-      >What you need to do is to add <code
-	>containers</code
-	> to the <code
-	>build-depends</code
-	> in your <code
-	>.cabal</code
-	> file.</p
-      ><p
-      >The reason you get this message is because when cabal asks ghc to build your package, it tells ghc to ignore all available packages except for the ones explicitly listed in the <code
-	>.cabal</code
-	> file. The terminology ghc uses for this is &quot;hidden&quot;.</p
-      ><p
-      >Do not be confused by the <code
-	>ghc-pkg</code
-	> tool commands to <code
-	>hide</code
-	> and <code
-	>expose</code
-	> packages. That makes no difference to this issue.</p
-      ></div
-    ><div id="hidden-packages-b"
-    ><h2
-      >Hidden packages (b)</h2
-      ><p
-      >You build a package (not one you're writing yourself) and get a message like:</p
-      ><pre
-      ><code
-	>Could not find module `Data.Map': it is a member of package
-containers-0.1.0.0, which is hidden.
-</code
-	></pre
-      ><p
-      >This is because the package has not been updated for ghc-6.8 which has split the base package into lots of smaller packages. The package needs to be updated to say that it depends on these new split base packages, like containers, process and several others.</p
-      ><p
-      >If you just want to get the package to build, add the missing package names to the build-depends: line in the .cabal file. For example given the above error message we would add the <code
-	>containers</code
-	> package to the build-depends.</p
-      ><p
-      >Developers of packages who want to know how to update their package properly so that it will continue to work with old and new compilers should see the article on <a href="http://haskell.org/haskellwiki/Upgrading_packages"
-	>upgrading packages</a
-	>.</p
-      ></div
-    ><div id="runprocess-does-not-exist"
-    ><h2
-      >runProcess: does not exist</h2
-      ><p
-      >You try to install a package on Windows and it fails with the message</p
-      ><pre
-      ><code
-	>sh: runProcess: does not exist (No such file or directory)
-</code
-	></pre
-      ><p
-      >What it means is that it cannot find the program <code
-	>sh.exe</code
-	> which is needed to run the <code
-	>./configure</code
-	> script that this package uses.</p
-      ><p
-      >Packages that use <code
-	>./configure</code
-	> scripts are not very good citizens on Windows. They have to be run from within an MSYS shell because <code
-	>./configure</code
-	> scripts are actually Unix shell scripts. The MSYS shell provides all the programs that the script needs to run.</p
-      ><p
-      >BTW, if you want to make the error message better see Cabal ticket <a href="http://hackage.haskell.org/trac/hackage/ticket/403"
-	>#403</a
-	>.</p
-      ></div
-    ><div id="exitfailure-1"
-    ><h2
-      >ExitFailure 1</h2
-      ><p
-      >You use cabal to build a bunch of packages and it fails with a message like:</p
-      ><pre
-      ><code
-	>cabal: Error: some packages failed to install: foo-1.0 failed during the
-configure step. The exception was: exit: ExitFailure 1
-</code
-	></pre
-      ><p
-      >Hooray for unhelpful error messages! Although this final message is unhelpful, there is almost always an actual error message further up in the build log. Try scrolling up to the bit where it was trying to build that package.</p
-      ></div
-    ><div id="runghc-setup-complains-of-missing-packages"
-    ><h2
-      >runghc Setup complains of missing packages</h2
-      ><blockquote
-      ><p
-	>I get</p
-	><pre
-	><code
-	  >$ runghc Setup.hs configure
-Configuring PER-0.0.20...
-Setup.hs: At least the following dependencies are missing:
-time -any &amp;&amp; -any
-</code
-	  ></pre
-	><p
-	>But I already have that package installed.</p
-	><pre
-	><code
-	  >$ ghc-pkg list time
-/usr/lib/ghc-6.10.1/./package.conf:
-/home/me/.ghc/x86-linux-6.10.1/package.conf:
-    time-1.1.2.4
-</code
-	  ></pre
-	></blockquote
-      ><p
-      >The default for <code
-	>runghc Setup.hs configure</code
-	> is <code
-	>--global</code
-	>, but the default for <code
-	>cabal configure</code
-	> is <code
-	>--user</code
-	>. Global packages cannot depend on user packages. So if you're using the <code
-	>cabal</code
-	> program to install packages, then you can also us it to configure other packages. There is usually no need to use <code
-	>runghc Setup.hs</code
-	> at all.</p
-      ><p
-      >If you need to use the <code
-	>runghc Setup.hs</code
-	> interface (e.g. in some system build scripts) and you want it to pick up packages from the user package db then use the <code
-	>--user</code
-	> flag. If you're constantly having to use the <code
-	>runghc Setup.hs</code
-	> interface and doing per-user installs is a pain then you can set the default for the cabal program to be global installs in the cabal config file (<code
-	>~/.cabal/config</code
-	>).</p
-      ></div
-    ><div id="parsec-2-vs-3"
-    ><h2
-      >Parsec 2 vs 3</h2
-      ><blockquote
-      ><p
-	>I just used cabal to install parsec. Why did it give me version 2 rather than 3?</p
-	></blockquote
-      ><p
-      >The default version of the parsec package is version 2.x. You can explicitly request version 3 using</p
-      ><pre
-      ><code
-	>$ cabal install 'parsec &gt;= 3'
-</code
-	></pre
-      ></div
-    ><div id="cabal-goes-into-an-infinite-loop--runs-out-of-memory"
-    ><h2
-      >Cabal goes into an infinite loop / runs out of memory</h2
-      ><blockquote
-      ><p
-	>I just upgraded to ghc-6.10 and now cabal runs out of memory when I try to install something</p
-	><pre
-	><code
-	  >Resolving dependencies...
-cabal: memory allocation failed (requested 2097152 bytes)
-</code
-	  ></pre
-	></blockquote
-      ><p
-      >This happens when you use cabal-install version 0.5.x with ghc-6.10. The older cabal-install version goes into an infinite loop when resolving dependencies because it cannot cope with the fact that base 3 depends on base 4.</p
-      ><p
-      >If you have still got ghc-6.8.x installed then you can upgrade to the latest cabal version using:</p
-      ><pre
-      ><code
-	>$ cabal install cabal-install --with-compiler=ghc-6.8.3
-</code
-	></pre
-      ><p
-      >otherwise you will need to bootstrap cabal-install freshly with ghc-6.10. When you have upgraded, double-check you have the right version on your <code
-	>$PATH</code
-	> using</p
-      ><pre
-      ><code
-	>$ cabal --version
-cabal-install version 0.6.2
-using version 1.6.0.2 of the Cabal library
-</code
-	></pre
-      ></div
-    ><div id="internal-error-invalid-install-plan"
-    ><h2
-      >Internal error: invalid install plan</h2
-      ><blockquote
-      ><pre
-	><code
-	  >$ cabal install leksah
-Resolving dependencies...
-cabal: internal error: could not construct a valid install plan.
-The proposed (invalid) plan contained the following problems:
-The following packages are involved in a dependency cycle leksah-0.10.0.4
-</code
-	  ></pre
-	></blockquote
-      ><p
-      >The solution is to upgrade cabal-install:</p
-      ><pre
-      ><code
-	>$ cabal install 'cabal-install &gt;= 0.10'
-</code
-	></pre
-      ><p
-      >This happens when you use an older version of cabal-install to try to install a package that uses a new Cabal feature that allows intra-package dependencies (that is, components within a package that depend on each other).</p
-      ><p
-      >The older version of cabal-install does not understand these new intra-package dependencies and it thinks that the package depends on itself (which would be a dependency cycle) so it gets upset.</p
-      ></div
-    ></body
-  ></html
->
-
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="" xml:lang="">
+<head>
+  <meta charset="utf-8" />
+  <meta name="generator" content="pandoc" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <meta name="author" content="" />
+  <title>Cabal FAQ</title>
+  <style type="text/css">
+      code{white-space: pre-wrap;}
+      span.smallcaps{font-variant: small-caps;}
+      span.underline{text-decoration: underline;}
+      div.column{display: inline-block; vertical-align: top; width: 50%;}
+  </style>
+  <link rel="stylesheet" href="nominolo.css" />
+</head>
+<body>
+<header>
+<h1 class="title">Cabal FAQ</h1>
+<p class="author"></p>
+</header>
+<h2 id="contents">Contents</h2>
+<p>Select the name of a problem to jump to a full explanation and solution.</p>
+<dl>
+<dt><a href="#hidden-packages">Hidden packages</a></dt>
+<dd>What is this hidden package? You’re writing your own package and you get:
+</dd>
+<dd><pre><code> Could not find module `Data.Map&#39;: it is a member of package
+ containers-0.1.0.0, which is hidden.</code></pre>
+</dd>
+<dt><a href="#runprocess-does-not-exist">runProcess: does not exist</a></dt>
+<dd>You’re building a package on Windows and you get:
+</dd>
+<dd><pre><code> sh: runProcess: does not exist (No such file or directory)</code></pre>
+</dd>
+<dt><a href="#exitfailure-1">ExitFailure 1</a></dt>
+<dd><code>ExitFailure 1</code> ??! Where is the real error message?
+</dd>
+<dd><pre><code>cabal: Error: some packages failed to install: foo-1.0 failed during the
+configure step. The exception was: exit: ExitFailure 1</code></pre>
+</dd>
+</dl>
+<h2 id="hidden-packages">Hidden packages</h2>
+<p>You build a package that you are writing yourself and get a message like:</p>
+<pre><code>Could not find module `Data.Map&#39;: it is a member of package
+containers-0.1.0.0, which is hidden.</code></pre>
+<p>What you need to do is to add <code>containers</code> to the <code>build-depends</code> in your <code>.cabal</code> file.</p>
+<p>The reason you get this message is because when cabal asks ghc to build your package, it tells ghc to ignore all available packages except for the ones explicitly listed in the <code>.cabal</code> file. The terminology ghc uses for this is “hidden”.</p>
+<p>Do not be confused by the <code>ghc-pkg</code> tool commands to <code>hide</code> and <code>expose</code> packages. That makes no difference to this issue.</p>
+<h2 id="runprocess-does-not-exist">runProcess: does not exist</h2>
+<p>You try to install a package on Windows and it fails with the message</p>
+<pre><code>sh: runProcess: does not exist (No such file or directory)</code></pre>
+<p>What it means is that it cannot find the program <code>sh.exe</code> which is needed to run the <code>./configure</code> script that this package uses.</p>
+<p>Packages that use <code>./configure</code> scripts are not very good citizens on Windows. They have to be run from within an MSYS shell because <code>./configure</code> scripts are actually Unix shell scripts. The MSYS shell provides all the programs that the script needs to run.</p>
+<p>BTW, if you want to make the error message better see Cabal ticket <a href="http://hackage.haskell.org/trac/hackage/ticket/403">#403</a>.</p>
+<h2 id="exitfailure-1">ExitFailure 1</h2>
+<p>You use cabal to build a bunch of packages and it fails with a message like:</p>
+<pre><code>cabal: Error: some packages failed to install: foo-1.0 failed during the
+configure step. The exception was: exit: ExitFailure 1</code></pre>
+<p>Hooray for unhelpful error messages! Although this final message is unhelpful, there is almost always an actual error message further up in the build log. Try scrolling up to the bit where it was trying to build that package.</p>
+</body>
+</html>

--- a/FAQ.markdown
+++ b/FAQ.markdown
@@ -7,19 +7,8 @@ Contents
 
 Select the name of a problem to jump to a full explanation and solution.
 
-[Dependencies conflict](#dependencies-conflict)
-:        cabal: dependencies conflict: ghc-6.10.1 requires process ==1.0.1.1 however
-         process-1.0.1.1 was excluded because ghc-6.10.1 requires process ==1.0.1.0
-
-[Hidden packages (a)](#hidden-packages-a)
+[Hidden packages](#hidden-packages)
 :    What is this hidden package? You're writing your own package and you get:
-
-:        Could not find module `Data.Map': it is a member of package
-         containers-0.1.0.0, which is hidden.
-
-
-[Hidden packages (b)](#hidden-packages-b)
-:    You're building some other package and you get:
 
 :        Could not find module `Data.Map': it is a member of package
          containers-0.1.0.0, which is hidden.
@@ -35,117 +24,8 @@ Select the name of a problem to jump to a full explanation and solution.
 :       cabal: Error: some packages failed to install: foo-1.0 failed during the
         configure step. The exception was: exit: ExitFailure 1
 
-[Parsec 2 vs 3](#parsec-2-vs-3)
-:    I just used cabal to install parsec. Why did it give me version 2 rather
-     than 3?
-
-[`runghc Setup` complains of missing packages](#runghc-setup-complains-of-missing-packages)
-:       $ runghc Setup.hs configure
-        Configuring blah-1.0...
-        Setup.hs: At least the following dependencies are missing:
-        time -any
-
-:    But I just did `cabal install time`! What is going on?
-
-
-[Cabal goes into an infinite loop / runs out of memory](#cabal-goes-into-an-infinite-loop--runs-out-of-memory)
-:    I just upgraded to ghc-6.10 and now cabal runs out of memory when I try to
-     install something
-
-:       Resolving dependencies...
-        cabal: memory allocation failed (requested 2097152 bytes)
-
-[internal error: could not construct a valid install plan](#internal-error-invalid-install-plan)
-:       $ cabal install leksah
-        Resolving dependencies...
-        cabal: internal error: could not construct a valid install plan.
-        The proposed (invalid) plan contained the following problems:
-        The following packages are involved in a dependency cycle leksah-0.10.0.4
-:    What's going on? How do I fix it?
-
-
-Dependencies conflict
----------------------
-
->     Resolving dependencies...
->     cabal: dependencies conflict: ghc-6.10.1 requires process ==1.0.1.1 however
->     process-1.0.1.1 was excluded because ghc-6.10.1 requires process ==1.0.1.0
->
-> What does this message mean? It makes little sense to me &mdash; ghc-6.10.1
-> requires both `process ==1.0.1.1` and `process ==1.0.1.0`?
-
-Yes, that's exactly what it looks like to Cabal which is why it is horribly
-confused.
-
-The reason is shadowing between the global and user package dbs. The way ghc
-package databases work is that the user one is just slapped on top of the global
-one. Like `Data.Map.union`.
-
-Suppose you've got these packages registered in the global package db:
-
-       A-1
-      / |
-     /  |
-    B-1 |
-     \  |
-      \ |
-       C-1.0.1.0
-
-Now, suppose you register B-1 in the user package db, then it masks the
-existing B-1 from the global db. But suppose that you build this instance
-against C-1.0.1.1...
-
-       A-1
-      / \
-     /   \
-    B-1   \
-     \     C-1.0.1.0
-      \
-       C-1.0.1.1
-
-Oh no! Now A-1 appears to depend on two versions of C! The cabal-install
-dependency resolver is designed to look for solutions where this does not
-happen, but here it's already happened in the installed packages, so it cannot
-ever pick the A-1 package as part of an install plan.
-
-It's not just cabal-install that will get confused here. ghc --make will too.
-If you're lucky you'll get linker errors. If you're unlucky you'll get
-segfaults.
-
-The solution we've been discussing for the next major ghc release is to track
-package ABIs and possibly even to allow slotting packages in their ABI. That
-would make this problem disappear and generally allow safer and more flexible
-management of installed packages.
-
-In the mean time I'm thinking of making the representation of installed package
-databases record broken packages. Then when we overlay package databases we
-could mark clashes like the above as breaking A-1. We should also try and get
-the solver to help us find solutions that avoid getting into this situation in
-the first place.
-
-> And, more importantly, how do I solve this?
-
-Run `ghc-pkg list` and look for packages where you have the same version
-registered in the user and global package db. Unreigister the user one. For
-example you might have `Cabal-1.6.0.1` registered per-user and globally.
-
-In this specific example you should also unregister `process-1.0.1.1`:
-
-    ghc-pkg unregister --user process-1.0.1.1
-
-If it says it'll break other things, then do it anyway using `--force`. But you
-will need to rebuild all those other packages that get broken. To check what
-packages are broken use:
-
-    ghc-pkg check
-
-To avoid this problem in the future, avoid upgrading core packages. The latest
-version of cabal-install has disabled the `upgrade` command to make it a bit
-harder for people to break their systems in this way.
-
-
-Hidden packages (a)
--------------------
+Hidden packages
+---------------
 
 You build a package that you are writing yourself and get a message like:
 
@@ -162,30 +42,6 @@ explicitly listed in the `.cabal` file. The terminology ghc uses for this is
 
 Do not be confused by the `ghc-pkg` tool commands to `hide` and
 `expose` packages. That makes no difference to this issue.
-
-
-Hidden packages (b)
--------------------
-
-You build a package (not one you're writing yourself) and get a message like:
-
-    Could not find module `Data.Map': it is a member of package
-    containers-0.1.0.0, which is hidden.
-
-This is because the package has not been updated for ghc-6.8 which has split
-the base package into lots of smaller packages. The package needs to be updated
-to say that it depends on these new split base packages, like containers,
-process and several others.
-
-If you just want to get the package to build, add the missing package names to
-the build-depends: line in the .cabal file. For example given the above error
-message we would add the `containers` package to the build-depends.
-
-Developers of packages who want to know how to update their package properly so
-that it will continue to work with old and new compilers should see the article
-on [upgrading packages].
-
-[upgrading packages]: http://haskell.org/haskellwiki/Upgrading_packages
 
 
 runProcess: does not exist
@@ -219,92 +75,3 @@ You use cabal to build a bunch of packages and it fails with a message like:
 Hooray for unhelpful error messages! Although this final message is unhelpful,
 there is almost always an actual error message further up in the build log. Try
 scrolling up to the bit where it was trying to build that package.
-
-runghc Setup complains of missing packages
----------------------------------------------
-
-> I get
->
->     $ runghc Setup.hs configure
->     Configuring PER-0.0.20...
->     Setup.hs: At least the following dependencies are missing:
->     time -any && -any
->
-> But I already have that package installed.
->
->     $ ghc-pkg list time
->     /usr/lib/ghc-6.10.1/./package.conf:
->     /home/me/.ghc/x86-linux-6.10.1/package.conf:
->         time-1.1.2.4
-
-The default for `runghc Setup.hs configure` is `--global`, but the default
-for `cabal configure` is `--user`. Global packages cannot depend on user
-packages. So if you're using the `cabal` program to install packages, then
-you can also us it to configure other packages. There is usually no need to
-use `runghc Setup.hs` at all.
-
-If you need to use the `runghc Setup.hs` interface (e.g. in some system build
-scripts) and you want it to pick up packages from the user package db then use
-the `--user` flag. If you're constantly having to use the `runghc Setup.hs`
-interface and doing per-user installs is a pain then you can set the default
-for the cabal program to be global installs in the cabal config file
-(`~/.cabal/config`).
-
-Parsec 2 vs 3
--------------
-
-> I just used cabal to install parsec.
-> Why did it give me version 2 rather than 3?
-
-The default version of the parsec package is version 2.x. You can explicitly
-request version 3 using
-
-    $ cabal install 'parsec >= 3'
-
-
-Cabal goes into an infinite loop / runs out of memory
------------------------------------------------------
-
-> I just upgraded to ghc-6.10 and now cabal runs out of memory when I try to
-> install something
->
->     Resolving dependencies...
->     cabal: memory allocation failed (requested 2097152 bytes)
-
-This happens when you use cabal-install version 0.5.x with ghc-6.10. The older
-cabal-install version goes into an infinite loop when resolving dependencies
-because it cannot cope with the fact that base 3 depends on base 4.
-
-If you have still got ghc-6.8.x installed then you can upgrade to the latest
-cabal version using:
-
-    $ cabal install cabal-install --with-compiler=ghc-6.8.3
-
-otherwise you will need to bootstrap cabal-install freshly with ghc-6.10. When
-you have upgraded, double-check you have the right version on your `$PATH` using
-
-    $ cabal --version
-    cabal-install version 0.6.2
-    using version 1.6.0.2 of the Cabal library
-
-Internal error: invalid install plan
-------------------------------------
-
->     $ cabal install leksah
->     Resolving dependencies...
->     cabal: internal error: could not construct a valid install plan.
->     The proposed (invalid) plan contained the following problems:
->     The following packages are involved in a dependency cycle leksah-0.10.0.4
-
-The solution is to upgrade cabal-install:
-
-    $ cabal install 'cabal-install >= 0.10'
-
-This happens when you use an older version of cabal-install to try to install
-a package that uses a new Cabal feature that allows intra-package dependencies
-(that is, components within a package that depend on each other).
-
-The older version of cabal-install does not understand these new intra-package
-dependencies and it thinks that the package depends on itself (which would be
-a dependency cycle) so it gets upset.
-


### PR DESCRIPTION
All of the FAQ questions seem to be pretty outdated. This PR removes the ones that are *extremely* outdated, specifically

* 💀 Dependencies conflict

  Refers to behaviour from old cabal that doesn't really occur with modern cabal (say from 3.0 onwards).  It mentions GHC 6.10!

* 💀 Hidden packages (b)

  It's about a library split that happened in GHC 6.8. It is no longer relevant.

* 💀 runghc Setup complains of missing packages

  This seems to be referring to a rather old way of installing packages.  I really doubt it is a *frequently* asked question.

* 💀 Parsec 2 vs 3

  Parsec 3 was released in 2008. Highly doubtful that this is an asked question, let alone frequently.

* 💀 Cabal goes into an infinite loop / runs out of memory

  "This happens when you use cabal-install version 0.5.x with ghc-6.10". cabal-install version 0.5 is from 2008.

* 💀 Internal error: invalid install plan

  Suggests upgrading to "cabal-install >= 0.10".  Was new in 2011, now severely out of date.

I ran `make` to generate `FAQ.html` from `FAQ.md`. I hope that was the right thing to do.
