### PR TITLE
Remove unhelpful link

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,7 +102,6 @@
       <li><a href="code.html">Source code</a> for development versions.
       <li>Questions can be <a href="mailto:libraries@haskell.org">sent</a> to the <a href="http://www.haskell.org/mailman/listinfo/libraries">Haskell libraries mailing list</a>
       <li>Development discussion takes place on the <a href="http://www.haskell.org/mailman/listinfo/cabal-devel">cabal-devel</a> mailing list</li>
-      <li><a href="old.html">Old stuff</a></li>
       <li><a href="http://www.haskell.org/haskellwiki/Applications_and_libraries">Applications and Libraries</a> for Haskell</li>
     </ul>
 


### PR DESCRIPTION
There doesn't seem to be any point in linking to "old stuff".  It's 15 years old. If anyone needs it surely they know where to find it.  On the other hand it will be confusing to almost everyone else.