### PR TITLE
Fix cabal downloads page + Add up to date information for 3.4

### DIFF
--- a/download.html
+++ b/download.html
@@ -14,15 +14,15 @@
 
     <p>For installation/upgrade instructions see <a href="index.html#install-upgrade">here</a>.</p>
 
-    <h2>Cabal library (version 3.2.0.0)</h2>
+    <h2>Cabal library (version 3.4.0.0)</h2>
 
-    <p><span style="font-weight: bolder">Released:</span> April 2020<br>
+    <p><span style="font-weight: bolder">Released:</span> February 2021<br>
 
-    <p><span style="font-weight: bolder">Source download:</span> <a href="https://downloads.haskell.org/~cabal/Cabal-3.2.0.0/Cabal-3.2.0.0.tar.gz">Cabal-3.2.0.0.tar.gz</a></p>
+    <p><span style="font-weight: bolder">Source download:</span> <a href="https://downloads.haskell.org/~cabal/Cabal-3.4.0.0/Cabal-3.4.0.0.tar.gz">Cabal-3.4.0.0.tar.gz</a></p>
 
     <p>Please see the <a href="https://cabal.readthedocs.io">User's guide</a>, the <a href="http://hackage.haskell.org/package/Cabal">API documentation</a>, and the <a href="http://hackage.haskell.org/package/Cabal/changelog">change log</a>.</p>
 
-    <h2>cabal-install tool (version 3.2.0.0)</h2>
+    <h2>cabal-install tool (version 3.4.0.0)</h2>
 
     <p><span class="inline-code">cabal-install</span> is the command
       line interface to Cabal and hackage.  This is the package that
@@ -31,27 +31,23 @@
       the <a href="http://hackage.haskell.org/package/cabal-install/changelog">change
       log</a> for information about what's new in this version.</p>
 
-    <p><span style="font-weight: bolder">Released:</span> April 2020<br>
+    <p><span style="font-weight: bolder">Released:</span> February 2021<br>
 
-    <p><span style="font-weight: bolder">Source download:</span> <a href="https://downloads.haskell.org/~cabal/cabal-install-3.2.0.0/cabal-install-3.2.0.0.tar.gz">cabal-install-3.2.0.0.tar.gz</a></p>
+    <p><span style="font-weight: bolder">Source download:</span> <a href="https://downloads.haskell.org/~cabal/cabal-install-3.4.0.0/cabal-install-3.4.0.0.tar.gz">cabal-install-3.4.0.0.tar.gz</a></p>
 
-    <p><span style="font-weight: bolder">Binary download for Windows (x86):</span> <a href="https://downloads.haskell.org/~cabal/cabal-install-3.2.0.0/cabal-install-3.2.0.0-i386-unknown-mingw32.zip">cabal-install-3.2.0.0-i386-unknown-mingw32.zip</a></p>
+    <p><span style="font-weight: bolder">Binary download for Windows (x86-64):</span> <a href="https://downloads.haskell.org/~cabal/cabal-install-3.4.0.0/cabal-install-3.4.0.0-x86_64-windows.zip">cabal-install-3.4.0.0-x86_64-windows.zip</a></p>
 
-    <p><span style="font-weight: bolder">Binary download for Windows (x86-64):</span> <a href="https://downloads.haskell.org/~cabal/cabal-install-3.2.0.0/cabal-install-3.2.0.0-x86_64-unknown-mingw32.zip">cabal-install-3.2.0.0-x86_64-unknown-mingw32.zip</a></p>
+    <p><span style="font-weight: bolder">Binary download for macOS High Sierra (x86-64):</span> <a href="https://downloads.haskell.org/~cabal/cabal-install-3.4.0.0/cabal-install-3.4.0.0-x86_64-darwin-sierra.tar.xz">cabal-install-3.4.0.0-x86_64-darwin-sierra.tar.xz</a></p>
 
-    <p><span style="font-weight: bolder">Binary download for macOS High Sierra (x86_64):</span> <a href="https://downloads.haskell.org/~cabal/cabal-install-3.2.0.0/cabal-install-3.2.0.0-x86_64-apple-darwin17.7.0.tar.xz">cabal-install-3.2.0.0-x86_64-apple-darwin17.7.0.tar.xz</a></p>
+    <p><span style="font-weight: bolder">Binary download for Debian Linux 9 (x86, requires glibc 2.12 or later):</span> <a href="https://downloads.haskell.org/~cabal/cabal-install-3.4.0.0/cabal-install-3.4.0.0-i386-debian-9.tar.xz">cabal-install-3.4.0.0-i386-debian-9.tar.xz</a></p>
 
-    <p><span style="font-weight: bolder">Binary download for Linux (x86, requires glibc 2.12 or later):</span> <a href="https://downloads.haskell.org/~cabal/cabal-install-3.2.0.0/cabal-install-3.2.0.0-i386-unknown-linux.tar.xz">cabal-install-3.2.0.0-i386-unknown-linux.tar.xz</a></p>
+    <p><span style="font-weight: bolder">Binary download for Ubuntu Linux 16.04 (x86-64, requires glibc 2.12 or later):</span> <a href="https://downloads.haskell.org/~cabal/cabal-install-3.4.0.0/cabal-install-3.4.0.0-x86_64-ubuntu-16.04.tar.xz">cabal-install-3.4.0.0-x86_64-ubuntu-16.04.tar.xz</a></p>
 
-    <p><span style="font-weight: bolder">Binary download for Linux (x86-64, requires glibc 2.12 or later):</span> <a href="https://downloads.haskell.org/~cabal/cabal-install-3.2.0.0/cabal-install-3.2.0.0-x86_64-unknown-linux.tar.xz">cabal-install-3.2.0.0-x86_64-unknown-linux.tar.xz</a></p>
+    <p><span style="font-weight: bolder">Binary download for Ubuntu Linux 18.04 (aarch64, requires glibc 2.12 or later):</span> <a href="https://downloads.haskell.org/~cabal/cabal-install-3.4.0.0/cabal-install-3.4.0.0-aarch64-ubuntu-18.04.tar.xz">cabal-install-3.4.0.0-aarch64-ubuntu-18.04.tar.xz</a></p>
 
-    <p><span style="font-weight: bolder">Binary download for Alpine Linux 3.8 (x86):</span> <a href="https://downloads.haskell.org/~cabal/cabal-install-3.2.0.0/cabal-install-3.2.0.0-i386-alpine-linux-musl.tar.xz">cabal-install-3.2.0.0-i386-alpine-linux-musl.tar.xz</a></p>
+    <p><span style="font-weight: bolder">Binary download for Alpine Linux 3.11 (x86-64):</span> <a href="https://downloads.haskell.org/~cabal/cabal-install-3.4.0.0/cabal-install-3.4.0.0-x86_64-alpine-3.11.6-static-noofd.tar.xz">cabal-install-3.4.0.0-x86_64-alpine-3.11.6-static-noofd.tar.xz</a></p>
 
-    <p><span style="font-weight: bolder">Binary download for Alpine Linux 3.8 (x86-64):</span> <a href="https://downloads.haskell.org/~cabal/cabal-install-3.2.0.0/cabal-install-3.2.0.0-x86_64-alpine-linux-musl.tar.xz">cabal-install-3.2.0.0-x86_64-alpine-linux-musl.tar.xz</a></p>
-
-    <p><span style="font-weight: bolder">Binary download for FreeBSD (x86-64, built on 11.2):</span> <a href="https://downloads.haskell.org/~cabal/cabal-install-3.2.0.0/cabal-install-3.2.0.0-x86_64-portbld-freebsd.tar.xz">cabal-install-2.4.1.0-x86_64-portbld-freebsd.tar.xz</a></p>
-
-    <p><span style="font-weight: bolder">Binary download for AIX (PowerPC):</span> <a href="https://downloads.haskell.org/~cabal/cabal-install-2.4.1.0/cabal-install-2.4.1.0-powerpc-ibm-aix7.1.0.0.tar.xz">cabal-install-2.4.1.0-powerpc-ibm-aix7.1.0.0.tar.xz</a></p>
+    <p><span style="font-weight: bolder">Binary download for FreeBSD (x86-64, built on 12.1):</span> <a href="https://downloads.haskell.org/~cabal/cabal-install-3.4.0.0/cabal-install-3.4.0.0-x86_64-freebsd-12.1-release.tar.xz">cabal-install-3.4.0.0-x86_64-freebsd-12.1-release.tar.xz</a></p>
 
     <!-- Looks like Halcyon was last updated 3 years ago, and the last
      cabal-install version it supports is 1.22.
@@ -88,14 +84,19 @@
     <h2>Older Releases</h2>
 
     <p>
-      The previous stable release series for Cabal was 3.0.x.
-      The previous stable release series for cabal-install was 3.0.x.
+      The previous stable release series for Cabal was 3.2.x.
+      The previous stable release series for cabal-install was 3.2.x.
 
     <p>
       The versions bundled with recent Haskell implementation releases include:
       <ul>
-    <li>GHC 8.10.1 includes Cabal 3.2.0.0.</li>
-    <li>GHC 8.8.3 includes Cabal 3.0.1.0.</li>
+    <li>GHC 9.0.1 includes Cabal 3.4.0.0.</li>
+    <li>GHC 8.10.4 includes Cabal 3.2.1.0.</li>
+    <!-- <li>GHC 8.10.3 includes Cabal 3.2.1.0.</li> -->
+    <!-- <li>GHC 8.10.2 includes Cabal 3.2.0.0.</li> -->
+    <!-- <li>GHC 8.10.1 includes Cabal 3.2.0.0.</li> -->
+    <li>GHC 8.8.4 includes Cabal 3.0.1.0.</li>
+    <!-- <li>GHC 8.8.3 includes Cabal 3.0.1.0.</li> -->
     <!-- <li>GHC 8.8.2 includes Cabal 3.0.1.0.</li>         -->
     <!-- <li>GHC 8.8.1 includes Cabal 3.0.0.0.</li> -->
     <li>GHC 8.6.5 includes Cabal 2.4.0.1.</li>
@@ -119,6 +120,8 @@
       </ul>
 
     <p>
+      <a href ="https://downloads.haskell.org/~cabal/Cabal-3.4.0.0/Cabal-3.4.0.0.tar.gz">3.4.0.0</a> February 2021<br>
+      <a href ="https://downloads.haskell.org/~cabal/Cabal-3.2.1.0/Cabal-3.2.1.0.tar.gz">3.2.1.0</a> October 2020<br>
       <a href ="https://downloads.haskell.org/~cabal/Cabal-3.2.0.0/Cabal-3.2.0.0.tar.gz">3.2.0.0</a> March 2020<br>
       <a href ="https://downloads.haskell.org/~cabal/Cabal-3.0.2.0/Cabal-3.0.2.0.tar.gz">3.0.2.0</a> March 2020<br>
       <a href ="https://downloads.haskell.org/~cabal/Cabal-3.0.1.0/Cabal-3.0.1.0.tar.gz">3.0.1.0</a> March 2020<br>

--- a/download.html
+++ b/download.html
@@ -59,7 +59,7 @@
 
     <p>Packages for Debian (multiple versions) are available on the <a href="http://downloads.haskell.org/debian/">Haskell.org APT repository</a>.</p>
 
-    <p>Packages for Windows are available via <a href="https://hub.zhox.com/posts/chocolatey-introduction/">Chocolatey</a>.</p>
+    <p>Packages for Windows are available via <a href="https://chocolatey.org/packages/cabal">Chocolatey</a>.</p>
 
     <p>HEAD binaries for macOS are available on <a href="https://haskell.futurice.com/">haskell.futurice.com</a></p>
 

--- a/download.html
+++ b/download.html
@@ -90,33 +90,14 @@
     <p>
       The versions bundled with recent Haskell implementation releases include:
       <ul>
-    <li>GHC 9.0.1 includes Cabal 3.4.0.0.</li>
-    <li>GHC 8.10.4 includes Cabal 3.2.1.0.</li>
-    <!-- <li>GHC 8.10.3 includes Cabal 3.2.1.0.</li> -->
-    <!-- <li>GHC 8.10.2 includes Cabal 3.2.0.0.</li> -->
-    <!-- <li>GHC 8.10.1 includes Cabal 3.2.0.0.</li> -->
-    <li>GHC 8.8.4 includes Cabal 3.0.1.0.</li>
-    <!-- <li>GHC 8.8.3 includes Cabal 3.0.1.0.</li> -->
-    <!-- <li>GHC 8.8.2 includes Cabal 3.0.1.0.</li>         -->
-    <!-- <li>GHC 8.8.1 includes Cabal 3.0.0.0.</li> -->
-    <li>GHC 8.6.5 includes Cabal 2.4.0.1.</li>
-    <li>GHC 8.4.4 includes Cabal 2.2.0.1.</li>
-    <li>GHC 8.2.2 includes Cabal 2.0.1.0.</li>
-    <!-- <li>GHC 8.2.1 includes Cabal 2.0.0.2.</li> -->
-    <li>GHC 8.0.2 includes Cabal 1.24.2.0.</li>
-    <!-- <li>GHC 8.0.1 includes Cabal 1.24.0.0.</li> -->
-    <li>GHC 7.10.3 includes Cabal 1.22.5.0.</li>
-    <!-- <li>GHC 7.8.4 includes Cabal 1.18.1.5.</li> -->
-    <!-- <li>GHC 7.8.1 includes Cabal 1.18.1.3.</li> -->
-    <!-- <li>GHC 7.4.1 includes Cabal 1.14.0.</li> -->
-    <!-- <li>GHC 7.2.2 includes Cabal 1.12.0.</li> -->
-    <!-- <li>GHC 7.0.4 includes Cabal 1.10.2.0.</li> -->
-    <!-- <li>GHC 6.12.3 includes Cabal 1.8.0.6.</li> -->
-    <!-- <li>GHC 6.10.4 includes Cabal 1.6.0.3.</li> -->
-    <!-- <li>GHC 6.8.3 includes Cabal 1.2.4.0.</li> -->
-    <!-- <li>GHC 6.6.1 includes Cabal 1.1.6.2.</li> -->
-    <!-- <li>Hugs98 September 2006 includes Cabal 1.1.5.9.2 (the 2nd release candidate for 1.1.6).</li> -->
-    <!-- <li>nhc98 1.20 includes Cabal-1.2.2.0.</li> -->
+        <li>GHC 9.0.1 includes Cabal 3.4.0.0</li>
+        <li>GHC 8.10.4 includes Cabal 3.2.1.0</li>
+        <li>GHC 8.8.4 includes Cabal 3.0.1.0</li>
+        <li>GHC 8.6.5 includes Cabal 2.4.0.1</li>
+        <li>GHC 8.4.4 includes Cabal 2.2.0.1</li>
+        <li>GHC 8.2.2 includes Cabal 2.0.1.0</li>
+        <li>GHC 8.0.2 includes Cabal 1.24.2.0</li>
+        <li>GHC 7.10.3 includes Cabal 1.22.5.0</li>
       </ul>
 
     <p>


### PR DESCRIPTION
TODO: 

- [x] `Cabal-3.2.1.0` and `Cabal-3.4.0.0` need to be uploaded to https://downloads.haskell.org/~cabal/
~~- [ ] `cabal-install-3.2.1.0` needs to be uploaded to https://downloads.haskell.org/~cabal/~~

There is no cabal-install-3.2.1.0 release.