### PR TITLE
Add older cabal-install downloads

### DIFF
--- a/download.html
+++ b/download.html
@@ -61,8 +61,6 @@
 
     <p>Packages for Windows are available via <a href="https://chocolatey.org/packages/cabal">Chocolatey</a>.</p>
 
-    <p>Packages for macOs are available on <a href="https://formulae.brew.sh/formula/cabal-install">Homebrew</a></p>
-
     <p>HEAD binaries for macOS are available on <a href="https://haskell.futurice.com/">haskell.futurice.com</a></p>
 
     <p>You also can use <a href="https://www.haskell.org/ghcup">ghcup</a> to install cabal-install on linux and macOs</p>

--- a/download.html
+++ b/download.html
@@ -12,7 +12,7 @@
 
     <h2>Install/Upgrade</h2>
 
-    <p>For installation/upgrade instructions see <a href="index.html#install-upgrade">here</a>.</p>
+    <p>For installation/upgrade instructions using a previous version of cabal-install see <a href="index.html#install-upgrade">here</a>.</p>
 
     <h2>Cabal library (version 3.4.0.0)</h2>
 
@@ -61,12 +61,17 @@
 
     <p>Packages for Windows are available via <a href="https://chocolatey.org/packages/cabal">Chocolatey</a>.</p>
 
+    <p>Packages for macOs are available on <a href="https://formulae.brew.sh/formula/cabal-install">Homebrew</a></p>
+
     <p>HEAD binaries for macOS are available on <a href="https://haskell.futurice.com/">haskell.futurice.com</a></p>
+
+    <p>You also can use <a href="https://www.haskell.org/ghcup">ghcup</a> to install cabal-install on linux and macOs</p>
 
     <p>The source package requires the Cabal package above and also further packages,
       which can be found on Hackage.
 
-      <h2>Bugs</h2>
+    <h2>Bugs</h2>
+    
     <p>Report bugs
       <a href="https://github.com/haskell/cabal/issues">here</a> or to the
       <a href="mailto:cabal-devel@haskell.org">cabal-devel</a> mailing list.</p>
@@ -84,7 +89,7 @@
     <h2>Older Releases</h2>
 
     <p>
-      The previous stable release series for Cabal was 3.2.x.
+      The previous stable release series for Cabal was 3.2.x.<br>
       The previous stable release series for cabal-install was 3.2.x.
 
     <p>
@@ -99,9 +104,20 @@
         <li>GHC 8.0.2 includes Cabal 1.24.2.0</li>
         <li>GHC 7.10.3 includes Cabal 1.22.5.0</li>
       </ul>
-
     <p>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-3.4.0.0/Cabal-3.4.0.0.tar.gz">3.4.0.0</a> February 2021<br>
+    
+    <h3>Older releases of cabal-install</h3>
+    <p>
+      <a href ="https://downloads.haskell.org/~cabal/cabal-install-3.2.0.0/">3.2.0.0</a> March 2020<br>
+      <a href ="https://downloads.haskell.org/~cabal/cabal-install-3.0.0.0/">3.0.0.0</a> August 2019<br>
+      <a href ="https://downloads.haskell.org/~cabal/cabal-install-2.4.1.0/">2.4.1.0</a> November 2018<br>
+      <a href ="https://downloads.haskell.org/~cabal/cabal-install-2.4.0.0/">2.4.0.0</a> September 2018<br>
+      <a href ="https://downloads.haskell.org/~cabal/cabal-install-2.2.0.0/">2.2.0.0</a> March 2018<br>
+      <a href ="https://downloads.haskell.org/~cabal/cabal-install-2.0.0.1/">2.0.0.1</a> December 2017<br>
+      <a href ="https://downloads.haskell.org/~cabal/cabal-install-2.0.0.0/">2.0.0.0</a> August 2017<br>
+      
+    <h3>Older releases of Cabal</h3>
+    <p>
       <a href ="https://downloads.haskell.org/~cabal/Cabal-3.2.1.0/Cabal-3.2.1.0.tar.gz">3.2.1.0</a> October 2020<br>
       <a href ="https://downloads.haskell.org/~cabal/Cabal-3.2.0.0/Cabal-3.2.0.0.tar.gz">3.2.0.0</a> March 2020<br>
       <a href ="https://downloads.haskell.org/~cabal/Cabal-3.0.2.0/Cabal-3.0.2.0.tar.gz">3.0.2.0</a> March 2020<br>
@@ -115,57 +131,9 @@
       <a href ="https://downloads.haskell.org/~cabal/Cabal-2.0.1.1/Cabal-2.0.1.1.tar.gz">2.0.1.1</a> December 2017<br>
       <a href ="https://downloads.haskell.org/~cabal/Cabal-2.0.1.0/Cabal-2.0.1.0.tar.gz">2.0.1.0</a> November 2017<br>
       <a href ="https://downloads.haskell.org/~cabal/Cabal-2.0.0.2/Cabal-2.0.0.2.tar.gz">2.0.0.2</a> August 2017<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.24.2.0/Cabal-1.24.2.0.tar.gz">1.24.2.0</a> December 2016<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.24.1.0/Cabal-1.24.1.0.tar.gz">1.24.1.0</a> October 2016<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.24.0.0/Cabal-1.24.0.0.tar.gz">1.24.0.0</a> May 2016<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.22.8.0/Cabal-1.22.8.0.tar.gz">1.22.8.0</a> March 2016<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.22.7.0/Cabal-1.22.7.0.tar.gz">1.22.7.0</a> January 2016<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.20.0.4/Cabal-1.20.0.4.tar.gz">1.20.0.4</a> January 2016<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.18.1.7/Cabal-1.18.1.7.tar.gz">1.18.1.7</a> January 2016<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.22.6.0/Cabal-1.22.6.0.tar.gz">1.22.6.0</a> December 2015<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.22.4.0/Cabal-1.22.4.0.tar.gz">1.22.4.0</a> June 2015<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.22.3.0/Cabal-1.22.3.0.tar.gz">1.22.3.0</a> April 2015<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.22.2.0/Cabal-1.22.2.0.tar.gz">1.22.2.0</a> March 2015<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.22.0.0/Cabal-1.22.0.0.tar.gz">1.22.0.0</a> January 2015<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.18.1.6/Cabal-1.18.1.6.tar.gz">1.18.1.6</a> January 2015<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.20.0.3/Cabal-1.20.0.3.tar.gz">1.20.0.3</a> December 2014<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.18.1.5/Cabal-1.18.1.5.tar.gz">1.18.1.5</a> December 2014<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.20.0.2/Cabal-1.20.0.2.tar.gz">1.20.0.2</a> July 2014<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.18.1.4/Cabal-1.18.1.4.tar.gz">1.18.1.4</a> July 2014<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.20.0.1/Cabal-1.20.0.1.tar.gz">1.20.0.1</a> May 2014<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.20.0.0/Cabal-1.20.0.0.tar.gz">1.20.0.0</a> April 2014<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.18.1.3/Cabal-1.18.1.3.tar.gz">1.18.1.3</a> March 2014<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.18.1.2/Cabal-1.18.1.2.tar.gz">1.18.1.2</a> October 2013<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.18.1.1/Cabal-1.18.1.1.tar.gz">1.18.1.1</a> October 2013<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.18.1/Cabal-1.18.1.tar.gz">1.18.1</a> September 2013<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.18.0/Cabal-1.18.0.tar.gz">1.18.0</a> September 2013<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.14.0/Cabal-1.14.0.tar.gz">1.14.0</a> February 2012<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.12.0/Cabal-1.12.0.tar.gz">1.12.0</a> January 2012<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.10.2.0/Cabal-1.10.2.0.tar.gz">1.10.2.0</a> June 2010<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.10.1.0/Cabal-1.10.1.0.tar.gz">1.10.1.0</a> February 2010<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.10.0.0/Cabal-1.10.0.0.tar.gz">1.10.0.0</a> November 2010<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.8.0.6/Cabal-1.8.0.6.tar.gz">1.8.0.6</a> June 2010<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.8.0.4/Cabal-1.8.0.4.tar.gz">1.8.0.4</a> March 2010<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.8.0.2/Cabal-1.8.0.2.tar.gz">1.8.0.2</a> December 2009<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.6.0.2/Cabal-1.6.0.2.tar.gz">1.6.0.2</a> February 2009<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.6.0.2/Cabal-1.6.0.2.tar.gz">1.6.0.2</a> February 2009<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.6.0.1/Cabal-1.6.0.1.tar.gz">1.6.0.1</a> October 2008<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.4.0.2/Cabal-1.4.0.2.tar.gz">1.4.0.2</a> August 2008<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.4.0.1/Cabal-1.4.0.1.tar.gz">1.4.0.1</a> June 2008<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.2.3.0/cabal-1.2.3.0.tar.gz">1.2.3.0</a> December 2007<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.2.2.0/cabal-1.2.2.0.tar.gz">1.2.2.0</a> October 2007<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.2.1.0/cabal-1.2.1.0.tar.gz">1.2.1.0</a> October 2007<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.1.6.2/cabal-1.1.6.2.tar.gz">1.2.0</a> September 2007<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.1.6.2/cabal-1.1.6.2.tar.gz">1.1.6.2</a> May 2007<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.1.6.1/cabal-1.1.6.1.tar.gz">1.1.6.1</a> October 2006<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.1.6/cabal-1.1.6.tar.gz">1.1.6</a> October 2006<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.1.4/cabal-1.1.4.tar.gz">1.1.4</a> May 2006<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-1.1.3/cabal-1.1.3.tar.gz">1.1.3</a> September 2005<br>
-      <a href="https://downloads.haskell.org/~cabal/old/cabal-1.1.1/cabal-1.1.1.tar.gz">1.1.1</a> July 2005<br>
-      <a href="https://downloads.haskell.org/~cabal/old/cabal-0.5.tgz">0.5</a> February 2005<br>
-      <a href="https://downloads.haskell.org/~cabal/old/cabal-0.4.tgz">0.4</a> January 2005<br>
-      <a href="https://downloads.haskell.org/~cabal/old/cabal-0.2.tgz">0.2</a> November 2004<br>
-      <a href="https://downloads.haskell.org/~cabal/old/cabal-0.1.tgz">0.1</a> August 2004<br>
+
+    <p>
+      You can browse the rest of releases in <a href ="https://downloads.haskell.org/~cabal">https://downloads.haskell.org/~cabal</a>
 
       <hr>
     <p><a href="index.html">Back to the Main Page</a></p>


### PR DESCRIPTION
* Adding Hombrew and ghcup as possible installation methods (they are quite popular)
* Cut older releases download at 2.0.0.0 (adding a final link to all downloads)
* I've needed sometimes download an older cabal-install to test it or workaround some bug of a newer version
  * However i never had to download Cabal the library

//cc @emilypi 