### PR TITLE
Fix download link for linux

### DIFF
--- a/download.html
+++ b/download.html
@@ -39,7 +39,7 @@
 
     <p><span style="font-weight: bolder">Binary download for macOS (x86-64):</span> <a href="https://downloads.haskell.org/~cabal/cabal-install-3.6.2.0/cabal-install-3.6.2.0-x86_64-darwin.tar.xz">cabal-install-3.6.2.0-x86_64-darwin.tar.xz</a></p>
 
-    <p><span style="font-weight: bolder">Binary download for Linux (x86-64, requires glibc 2.12 or later):</span> <a href="https://downloads.haskell.org/~cabal/cabal-install-3.6.2.0/cabal-install-3.6.2.0-x86_64-linux.tar.xz">cabal-install-3.6.2.0-x86_64-linux.tar.xz</a></p>
+    <p><span style="font-weight: bolder">Binary download for Debian 10 (x86-64, requires glibc 2.12 or later):</span> <a href="https://downloads.haskell.org/~cabal/cabal-install-3.6.2.0/cabal-install-3.6.2.0-x86_64-linux-deb10.tar.xz">cabal-install-3.6.2.0-x86_64-linux-deb10.tar.xz</a></p>
 
     <p><span style="font-weight: bolder">Binary download for Debian 10 (aarch64, requires glibc 2.12 or later):</span> <a href="https://downloads.haskell.org/~cabal/cabal-install-3.6.2.0/cabal-install-3.6.2.0-aarch64-linux-deb10.tar.xz">cabal-install-3.6.2.0-aarch64-linux-deb10.tar.xz</a></p>
 


### PR DESCRIPTION
* As reported in https://github.com/haskell/cabal/issues/7994 and https://github.com/haskell/cabal/issues/8001