### PR TITLE
Remove HVR's PPA from the list of binary sources

### DIFF
--- a/download.html
+++ b/download.html
@@ -55,8 +55,6 @@
      <p>Binaries for cabal-install for many platforms are available
        on <a href="https://halcyon.sh/">Halcyon</a>.</p> -->
 
-    <p>Packages for Ubuntu Linux (multiple versions) are available on <a href="https://launchpad.net/~hvr/+archive/ubuntu/ghc">hvr's PPA</a>.</p>
-
     <p>Packages for Debian (multiple versions) are available on the <a href="http://downloads.haskell.org/debian/">Haskell.org APT repository</a>.</p>
 
     <p>Packages for Windows are available via <a href="https://chocolatey.org/packages/cabal">Chocolatey</a>.</p>


### PR DESCRIPTION
It's not active currently.  Initially reported at haskell/cabal#8209.