### PR TITLE
Update download page for cabal 3.10

### DIFF
--- a/download.html
+++ b/download.html
@@ -18,7 +18,7 @@
 
     <p><span style="font-weight: bolder">Released:</span> March 2023<br>
 
-    <p><span style="font-weight: bolder">Source download:</span> <a href="https://downloads.haskell.org/~cabal/Cabal-3.10.1.0/">Cabal-3.10.1.0/</a></p>
+    <p><span style="font-weight: bolder">Source download:</span> <a href="https://downloads.haskell.org/~cabal/Cabal-3.10.1.0/Cabal-3.10.1.0.tar.gz">Cabal-3.10.1.0.tar.gz</a> (with a checksum in file SHA256SUMS in <a href="https://downloads.haskell.org/~cabal/Cabal-3.10.1.0/">Cabal-3.10.1.0/</a>)</p>
 
     <p>Please see the <a href="https://cabal.readthedocs.io">User's guide</a>, the <a href="http://hackage.haskell.org/package/Cabal">API documentation</a>, and the <a href="http://hackage.haskell.org/package/Cabal/changelog">change log</a>.</p>
 

--- a/download.html
+++ b/download.html
@@ -14,15 +14,15 @@
 
     <p>For installation/upgrade instructions using a previous version of cabal-install see <a href="index.html#install-upgrade">here</a>.</p>
 
-    <h2>Cabal library (version 3.8.1.0)</h2>
+    <h2>Cabal library (version 3.10.1.0)</h2>
 
-    <p><span style="font-weight: bolder">Released:</span> August 2022<br>
+    <p><span style="font-weight: bolder">Released:</span> March 2023<br>
 
-    <p><span style="font-weight: bolder">Source download:</span> <a href="https://downloads.haskell.org/~cabal/Cabal-3.8.1.0/">Cabal-3.8.1.0/</a></p>
+    <p><span style="font-weight: bolder">Source download:</span> <a href="https://downloads.haskell.org/~cabal/Cabal-3.10.1.0/">Cabal-3.10.1.0/</a></p>
 
     <p>Please see the <a href="https://cabal.readthedocs.io">User's guide</a>, the <a href="http://hackage.haskell.org/package/Cabal">API documentation</a>, and the <a href="http://hackage.haskell.org/package/Cabal/changelog">change log</a>.</p>
 
-    <h2>cabal-install tool (version 3.8.1.0)</h2>
+    <h2>cabal-install tool (version 3.10.1.0)</h2>
 
     <p><span class="inline-code">cabal-install</span> is the command
       line interface to Cabal and hackage.  This is the package that
@@ -31,30 +31,9 @@
       the <a href="http://hackage.haskell.org/package/cabal-install/changelog">change
       log</a> for information about what's new in this version.</p>
 
-    <p><span style="font-weight: bolder">Released:</span> August 2022<br>
+    <p><span style="font-weight: bolder">Released:</span> March 2023<br>
 
-    <p><span style="font-weight: bolder">Source download:</span> <a href="https://downloads.haskell.org/~cabal/cabal-install-3.8.1.0/">cabal-install-3.8.1.0/</a></p>
-
-    <p><span style="font-weight: bolder">Binary download for Windows (x86-64):</span> <a href="https://downloads.haskell.org/~cabal/cabal-install-3.8.1.0/cabal-install-3.8.1.0-x86_64-windows.zip">cabal-install-3.8.1.0-x86_64-windows.zip</a></p>
-
-    <p><span style="font-weight: bolder">Binary download for macOS (x86-64):</span> <a href="https://downloads.haskell.org/~cabal/cabal-install-3.8.1.0/cabal-install-3.8.1.0-x86_64-darwin.tar.xz">cabal-install-3.8.1.0-x86_64-darwin.tar.xz</a></p>
-
-    <p><span style="font-weight: bolder">Binary download for Debian 10 (x86-64, requires glibc 2.12 or later):</span> <a href="https://downloads.haskell.org/~cabal/cabal-install-3.8.1.0/cabal-install-3.8.1.0-x86_64-linux-deb10.tar.xz">cabal-install-3.8.1.0-x86_64-linux-deb10.tar.xz</a></p>
-
-    <p><span style="font-weight: bolder">Binary download for Debian 10 (aarch64, requires glibc 2.12 or later):</span> <a href="https://downloads.haskell.org/~cabal/cabal-install-3.8.1.0/cabal-install-3.8.1.0-aarch64-linux-deb10.tar.xz">cabal-install-3.8.1.0-aarch64-linux-deb10.tar.xz</a></p>
-
-    <p><span style="font-weight: bolder">Binary download for Alpine Linux (x86-64):</span> <a href="https://downloads.haskell.org/~cabal/cabal-install-3.8.1.0/cabal-install-3.8.1.0-x86_64-linux-alpine.tar.xz">cabal-install-3.8.1.0-x86_64-linux-alpine.tar.xz</a></p>
-
-   <!-- gitlab CI currently fails for those:
-    <p><span style="font-weight: bolder">Binary download for Debian 10 (armv7, requires glibc 2.12 or later):</span> <a href="https://downloads.haskell.org/~cabal/cabal-install-3.8.1.0/cabal-install-3.8.1.0-armv7-linux-deb10.tar.xz">cabal-install-3.8.1.0-armv7-linux-deb10.tar.xz</a></p>
-
-    <p><span style="font-weight: bolder">Binary download for FreeBSD (x86-64):</span> <a href="https://downloads.haskell.org/~cabal/cabal-install-3.8.1.0/cabal-install-3.8.1.0-x86_64-freebsd.tar.xz">cabal-install-3.8.1.0-x86_64-freebsd.tar.xz</a></p> -->
-
-    <!-- Looks like Halcyon was last updated 3 years ago, and the last
-     cabal-install version it supports is 1.22.
-
-     <p>Binaries for cabal-install for many platforms are available
-       on <a href="https://halcyon.sh/">Halcyon</a>.</p> -->
+    <p><span style="font-weight: bolder">Source and binary downloads:</span> <a href="https://downloads.haskell.org/~cabal/cabal-install-3.10.1.0/">cabal-install-3.10.1.0/</a></p>
 
     <p>Packages for Debian (multiple versions) are available on the <a href="http://downloads.haskell.org/debian/">Haskell.org APT repository</a>.</p>
 
@@ -64,7 +43,7 @@
 
     <p>You also can use <a href="https://www.haskell.org/ghcup">ghcup</a></p>
 
-    <p>The source package requires the Cabal package above and also further packages,
+    <p>To build any of the source packages, you also need further packages,
       which can be found on Hackage.
 
     <h2>Bugs</h2>
@@ -86,12 +65,9 @@
     <h2>Older Releases</h2>
 
     <p>
-      The previous stable release series for Cabal was 3.4.x.<br>
-      The previous stable release series for cabal-install was 3.4.x.
-
-    <p>
       The versions bundled with recent Haskell implementation releases include:
       <ul>
+        <li>GHC 9.6.1 includes Cabal 3.10.1.0</li>
         <li>GHC 9.4.1 includes Cabal 3.8.1.0</li>
         <li>GHC 9.2.4 includes Cabal 3.6.3.0</li>
         <li>GHC 9.2.1 includes Cabal 3.6.0.0</li>
@@ -106,42 +82,8 @@
       </ul>
     <p>
 
-    <h3>Older releases of cabal-install</h3>
     <p>
-      <a href ="https://downloads.haskell.org/~cabal/cabal-install-3.6.2.0/">3.6.2.0</a> October 2021<br>
-      <a href ="https://downloads.haskell.org/~cabal/cabal-install-3.4.1.0/">3.4.1.0</a> October 2021<br>
-      <a href ="https://downloads.haskell.org/~cabal/cabal-install-3.4.0.0/">3.4.0.0</a> February 2021<br>
-      <a href ="https://downloads.haskell.org/~cabal/cabal-install-3.2.0.0/">3.2.0.0</a> March 2020<br>
-      <a href ="https://downloads.haskell.org/~cabal/cabal-install-3.0.0.0/">3.0.0.0</a> August 2019<br>
-      <a href ="https://downloads.haskell.org/~cabal/cabal-install-2.4.1.0/">2.4.1.0</a> November 2018<br>
-      <a href ="https://downloads.haskell.org/~cabal/cabal-install-2.4.0.0/">2.4.0.0</a> September 2018<br>
-      <a href ="https://downloads.haskell.org/~cabal/cabal-install-2.2.0.0/">2.2.0.0</a> March 2018<br>
-      <a href ="https://downloads.haskell.org/~cabal/cabal-install-2.0.0.1/">2.0.0.1</a> December 2017<br>
-      <a href ="https://downloads.haskell.org/~cabal/cabal-install-2.0.0.0/">2.0.0.0</a> August 2017<br>
-
-    <h3>Older releases of Cabal</h3>
-    <p>
-      <a href ="https://hackage.haskell.org/package/Cabal-3.6.3.0/Cabal-3.6.3.0.tar.gz">3.6.3.0</a> March 2022<br>
-      <a href ="https://hackage.haskell.org/package/Cabal-3.6.2.0/Cabal-3.6.2.0.tar.gz">3.6.2.0</a> October 2021<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-3.6.1.0/Cabal-3.6.1.0.tar.gz">3.6.1.0</a> September 2021<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-3.6.0.0/Cabal-3.6.0.0.tar.gz">3.6.0.0</a> August 2021<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-3.4.0.0/Cabal-3.4.0.0.tar.gz">3.4.0.0</a> February 2021<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-3.2.1.0/Cabal-3.2.1.0.tar.gz">3.2.1.0</a> October 2020<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-3.2.0.0/Cabal-3.2.0.0.tar.gz">3.2.0.0</a> March 2020<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-3.0.2.0/Cabal-3.0.2.0.tar.gz">3.0.2.0</a> March 2020<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-3.0.1.0/Cabal-3.0.1.0.tar.gz">3.0.1.0</a> March 2020<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-3.0.0.0/Cabal-3.0.0.0.tar.gz">3.0.0.0</a> August 2019<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-2.4.1.0/Cabal-2.4.1.0.tar.gz">2.4.1.0</a> November 2018<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-2.4.0.1/Cabal-2.4.0.1.tar.gz">2.4.0.1</a> September 2018<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-2.4.0.0/Cabal-2.4.0.0.tar.gz">2.4.0.0</a> September 2018<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-2.2.0.1/Cabal-2.2.0.1.tar.gz">2.2.0.1</a> March 2018<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-2.2.0.0/Cabal-2.2.0.0.tar.gz">2.2.0.0</a> March 2018<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-2.0.1.1/Cabal-2.0.1.1.tar.gz">2.0.1.1</a> December 2017<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-2.0.1.0/Cabal-2.0.1.0.tar.gz">2.0.1.0</a> November 2017<br>
-      <a href ="https://downloads.haskell.org/~cabal/Cabal-2.0.0.2/Cabal-2.0.0.2.tar.gz">2.0.0.2</a> August 2017<br>
-
-    <p>
-      You can browse the rest of releases in <a href ="https://downloads.haskell.org/~cabal">https://downloads.haskell.org/~cabal</a>
+      You can browse the older releases of cabal in <a href ="https://downloads.haskell.org/~cabal">https://downloads.haskell.org/~cabal</a>
 
       <hr>
     <p><a href="index.html">Back to the Main Page</a></p>


### PR DESCRIPTION
I've also simplified the page a lot, but it still needs a full overhaul (and the other pages, too).