### PR TITLE
Update install instructions on landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
 
     <p>
       The recommended method to install the <span class="inline-code">cabal</span> executable is to use <a href="https://www.haskell.org/ghcup/">ghcup</a>, which can manage multiple versions of <span class="inline-code">cabal</span> on Linux, Mac and Windows.
-      Alternatively, you can install <span class="inline-code">cabal</span> using your distributions package manager (if you are using Linux or Mac), or download the source or prebuilt binary from
+      Alternatively, you can install <span class="inline-code">cabal</span> using your distribution's package manager (if you are using Linux or Mac), or download the source or prebuilt binary from
       the <a href="download.html">Download</a> page.
     </p>
 
@@ -44,22 +44,15 @@
       <code>
 	<span class="code-unselectable"data-text="$ "></span>cabal install cabal-install
       </code><br>
-    </p>
-
-    <p>
-      If the above command failed for any reason see the <a href="#troubleshooting">Update Troubleshooting</a> section below.
-    </p>
-
-    <p>
-      Sometimes the older installed version is still on the program search
-      <span class="inline-code">$PATH</span>, you can check you're running the
-      latest version with the command below. If it doesn't match the output of
-      the <span class="inline-code">cabal-install</span> command above you'll
-      need to replace the old executable with the new one.<br>
-
+      This will install the cabal executable in cabal's <span class="inline-code">installdir</span> (usually <span class="inline-code">~/.local/bin</span>). In order to use this executable, you have to make sure that this directory appears in the <span class="inline-code">$PATH</span> variable before the location where your current cabal executable is located.
+      You can check which version of the cabal executable you are running by executing the command below.
       <code>
-	<span class="code-unselectable" data-text="$ ">cabal --version</span>
+        <span class="code-unselectable" data-text="$ ">cabal --version</span>
       </code>
+    </p>
+
+    <p>
+      If the update failed for any reason, see the <a href="#troubleshooting">Update Troubleshooting</a> section below.
     </p>
 
     <h2>Quick Start Guide</h2>

--- a/index.html
+++ b/index.html
@@ -33,16 +33,14 @@
     <h2><a href="#install-upgrade">Install/Upgrade <span class="inline-code">cabal</span></a></h2>
 
     <p>
-      To install the <span class="inline-code">cabal</span> executable you can
-      use <a href="https://gitlab.haskell.org/haskell/ghcup-hs">ghcup</a> (if you're using
-      Linux), the <a href="https://www.haskell.org/platform/">Haskell
-      Platform</a>, install the <span class="inline-code">cabal-install</span>
-      package from your distributions package manager (if using Linux or Mac),
-      or download the source or prebuilt binary from
+      The recommended method to install the <span class="inline-code">cabal</span> executable is to use <a href="https://www.haskell.org/ghcup/">ghcup</a>, which can manage multiple versions of <span class="inline-code">cabal</span> on Linux, Mac and Windows.
+      Alternatively, you can install <span class="inline-code">cabal</span> using your distributions package manager (if you are using Linux or Mac), or download the source or prebuilt binary from
       the <a href="download.html">Download</a> page.
+    </p>
 
     <p>
-      If you already have the <span class="inline-code">cabal</span> executable you can upgrade it by running:
+      If you have installed <span class="inline-code">cabal</span> using <a href="https://www.haskell.org/ghcup/">ghcup</a>, then you can also upgrade it using <span class="inline-code">ghcup</span>.
+      If you installed the <span class="inline-code">cabal</span> executable using a different method, you can upgrade it by running:
       <code>
 	<span class="code-unselectable"data-text="$ "></span>cabal install cabal-install
       </code><br>
@@ -66,7 +64,9 @@
 
     <h2>Quick Start Guide</h2>
 
-    <p>Start by installing the <span class="inline-code">cabal</span> executable (see <a href="#install-upgrade">the previous section</a>) and the Haskell compiler <span class="inline-code">ghc</span> (see <a href="https://www.haskell.org/ghc/download.html">the GHC download docs</a>).</p>
+    <p>Start by installing the <span class="inline-code">cabal</span> executable (see <a href="#install-upgrade">the previous section</a>) and the Haskell compiler <span class="inline-code">ghc</span>.
+      It is also recommended to use <a href="https://www.haskell.org/ghcup/">ghcup</a> to install <span class="inline-code">ghc</span>.
+    </p>
 
     <h3>Starting a new project</h3>
     <p>

--- a/index.html
+++ b/index.html
@@ -33,18 +33,25 @@
     <h2><a href="#install-upgrade">Install/Upgrade <span class="inline-code">cabal</span></a></h2>
 
     <p>
-      The recommended method to install the <span class="inline-code">cabal</span> executable is to use <a href="https://www.haskell.org/ghcup/">ghcup</a>, which can manage multiple versions of <span class="inline-code">cabal</span> on Linux, Mac and Windows.
-      Alternatively, you can install <span class="inline-code">cabal</span> using your distribution's package manager (if you are using Linux or Mac), or download the source or prebuilt binary from
-      the <a href="download.html">Download</a> page.
+      The recommended method to install the <span class="inline-code">cabal</span> executable
+      is to use <a href="https://www.haskell.org/ghcup/">ghcup</a>, which can manage multiple
+      versions of <span class="inline-code">cabal</span> on Linux, Mac and Windows.
+      Alternatively, you can install <span class="inline-code">cabal</span> using your
+      distribution's package manager (if you are using Linux or Mac), or download the source
+      or prebuilt binary from the <a href="download.html">Download</a> page.
     </p>
 
     <p>
-      If you have installed <span class="inline-code">cabal</span> using <a href="https://www.haskell.org/ghcup/">ghcup</a>, then you can also upgrade it using <span class="inline-code">ghcup</span>.
+      If you have installed <span class="inline-code">cabal</span> using <a href="https://www.haskell.org/ghcup/">ghcup</a>,
+      then you can also upgrade it using <span class="inline-code">ghcup</span>.
       If you installed the <span class="inline-code">cabal</span> executable using a different method, you can upgrade it by running:
       <code>
 	<span class="code-unselectable"data-text="$ "></span>cabal install cabal-install
       </code><br>
-      This will install the cabal executable in cabal's <span class="inline-code">installdir</span> (usually <span class="inline-code">~/.local/bin</span>). In order to use this executable, you have to make sure that this directory appears in the <span class="inline-code">$PATH</span> variable before the location where your current <span class="inline-code">cabal</span> executable is located.
+      This will install the cabal executable in cabal's <span class="inline-code">installdir</span>
+      (usually <span class="inline-code">~/.local/bin</span>). In order to use this executable,
+      you have to make sure that this directory appears in the <span class="inline-code">$PATH</span>
+      variable before the location where your current <span class="inline-code">cabal</span> executable is located.
       You can check which version of the <span class="inline-code">cabal</span> executable you are running by executing the command below.
       <code>
         <span class="code-unselectable" data-text="$ ">cabal --version</span>
@@ -57,7 +64,8 @@
 
     <h2>Quick Start Guide</h2>
 
-    <p>Start by installing the <span class="inline-code">cabal</span> executable (see <a href="#install-upgrade">the previous section</a>) and the Haskell compiler <span class="inline-code">ghc</span>.
+    <p>Start by installing the <span class="inline-code">cabal</span> executable
+      (see <a href="#install-upgrade">the previous section</a>) and the Haskell compiler <span class="inline-code">ghc</span>.
       It is also recommended to use <a href="https://www.haskell.org/ghcup/">ghcup</a> to install <span class="inline-code">ghc</span>.
     </p>
 

--- a/index.html
+++ b/index.html
@@ -68,7 +68,8 @@
 
     <p>Start by installing the <span class="inline-code">cabal</span> executable
       (see <a href="#install-upgrade">the previous section</a>) and the Haskell compiler <span class="inline-code">ghc</span>.
-      It is also recommended to use <a href="https://www.haskell.org/ghcup/">ghcup</a> to install <span class="inline-code">ghc</span>.
+      It is also recommended to use <a href="https://www.haskell.org/ghcup/">ghcup</a> to install 
+      <span class="inline-code">ghc</span>.
     </p>
 
     <h3>Starting a new project</h3>

--- a/index.html
+++ b/index.html
@@ -44,8 +44,8 @@
       <code>
 	<span class="code-unselectable"data-text="$ "></span>cabal install cabal-install
       </code><br>
-      This will install the cabal executable in cabal's <span class="inline-code">installdir</span> (usually <span class="inline-code">~/.local/bin</span>). In order to use this executable, you have to make sure that this directory appears in the <span class="inline-code">$PATH</span> variable before the location where your current cabal executable is located.
-      You can check which version of the cabal executable you are running by executing the command below.
+      This will install the cabal executable in cabal's <span class="inline-code">installdir</span> (usually <span class="inline-code">~/.local/bin</span>). In order to use this executable, you have to make sure that this directory appears in the <span class="inline-code">$PATH</span> variable before the location where your current <span class="inline-code">cabal</span> executable is located.
+      You can check which version of the <span class="inline-code">cabal</span> executable you are running by executing the command below.
       <code>
         <span class="code-unselectable" data-text="$ ">cabal --version</span>
       </code>

--- a/index.html
+++ b/index.html
@@ -44,7 +44,8 @@
     <p>
       If you have installed <span class="inline-code">cabal</span> using <a href="https://www.haskell.org/ghcup/">ghcup</a>,
       then you can also upgrade it using <span class="inline-code">ghcup</span>.
-      If you installed the <span class="inline-code">cabal</span> executable using a different method, you can upgrade it by running:
+      If you installed the <span class="inline-code">cabal</span> executable using a different method, 
+      you can upgrade it by running:
       <code>
 	<span class="code-unselectable"data-text="$ "></span>cabal install cabal-install
       </code><br>

--- a/index.html
+++ b/index.html
@@ -61,7 +61,8 @@
     </p>
 
     <p>
-      If the update failed for any reason, see the <a href="#troubleshooting">Update Troubleshooting</a> section below.
+      If the update failed for any reason, see the <a href="#troubleshooting">Update Troubleshooting</a> 
+      section below.
     </p>
 
     <h2>Quick Start Guide</h2>

--- a/index.html
+++ b/index.html
@@ -53,7 +53,8 @@
       (usually <span class="inline-code">~/.local/bin</span>). In order to use this executable,
       you have to make sure that this directory appears in the <span class="inline-code">$PATH</span>
       variable before the location where your current <span class="inline-code">cabal</span> executable is located.
-      You can check which version of the <span class="inline-code">cabal</span> executable you are running by executing the command below.
+      You can check which version of the <span class="inline-code">cabal</span> executable
+      you are running by executing the command below.
       <code>
         <span class="code-unselectable" data-text="$ ">cabal --version</span>
       </code>

--- a/index.html
+++ b/index.html
@@ -68,7 +68,8 @@
     <h2>Quick Start Guide</h2>
 
     <p>Start by installing the <span class="inline-code">cabal</span> executable
-      (see <a href="#install-upgrade">the previous section</a>) and the Haskell compiler <span class="inline-code">ghc</span>.
+      (see <a href="#install-upgrade">the previous section</a>) and the Haskell compiler
+      <span class="inline-code">ghc</span>.
       It is also recommended to use <a href="https://www.haskell.org/ghcup/">ghcup</a> to install 
       <span class="inline-code">ghc</span>.
     </p>


### PR DESCRIPTION
Fixes #37 

Haskell platform is officially deprecated, and using ghcup to install cabal and ghc is strongly recommended for beginners.